### PR TITLE
change social-chat to intense

### DIFF
--- a/org.srb2.SRB2Persona.metainfo.xml
+++ b/org.srb2.SRB2Persona.metainfo.xml
@@ -60,7 +60,7 @@
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">moderate</content_attribute>
     <content_attribute id="language-humor">mild</content_attribute>
-    <content_attribute id="social-chat">mild</content_attribute>
+    <content_attribute id="social-chat">intense</content_attribute>
     <content_attribute id="social-info">mild</content_attribute>
   </content_rating>
 </component>


### PR DESCRIPTION
In SRB2Persona servers, chat is usually unmoderated. it must be moderated by whoever is hosting the server, and isn't handled by the game, which means the rating has to be intense. This rating was also given to SRB2 and Ring Racers for the same reason, as well as GZDoom, but Ring Racers has voice chat too so that upped its rating.

But the age rating says it has no chat functionality
<img width="1512" height="463" alt="Screenshot 2026-04-04 at 11 18 18 AM" src="https://github.com/user-attachments/assets/42d4a5b0-e040-4040-aa9a-90599b03270a" />

thank you
